### PR TITLE
Fixed page reload bug for windows OS

### DIFF
--- a/GameManipulator.js
+++ b/GameManipulator.js
@@ -208,7 +208,7 @@ GameManipulator.startNewGame = function (next) {
     // Press space to begin game (repetidelly)
     _startKeyInterval = setInterval(function (){
       // Due to dino slowly gliding over the screen after multiple restarts, its better to just reload the page
-      robot.keyTap('r','command');
+      GameManipulator.reloadPage();
       setTimeout(function() {
         // Once reloaded we wait 0.5sec for it to let us start the game with a space.
           robot.keyTap(' ');
@@ -226,6 +226,19 @@ GameManipulator.startNewGame = function (next) {
   }
 
 
+}
+
+// reload the page
+GameManipulator.reloadPage = function ()
+{
+  // retrieves platform
+  var platform = process.platform;
+
+  if(/^win/.test(process.platform)) {
+    robot.keyTap('r','control');
+  } else if(/^darwin/.test(process.platform)) {
+    robot.keyTap('r','command');
+  }
 }
 
 


### PR DESCRIPTION
The key commands to reload the page is different on windows than it is on mac.

I created a function that handles that.
I didn't add anything for linux because I don't have a linux system to test on.