### PR TITLE
compatible(chrome): v59 changed the `GAME OVER` position. (fix #50)

### DIFF
--- a/GameManipulator.js
+++ b/GameManipulator.js
@@ -28,7 +28,7 @@ var GameManipulator = {
   gamestate: 'OVER',
 
   // GameOver Position
-  gameOverOffset: [190, -82],
+  gameOverOffset: [190, -75],
 
   // Stores an array of "sensors" (Ray tracings)
   // Positions are always relative to global "offset"


### PR DESCRIPTION
I did not test the other chrome because I do not have.

But I think it should work for the previous versions.