### PR TITLE
Fix GameOver detection

### DIFF
--- a/GameManipulator.js
+++ b/GameManipulator.js
@@ -28,7 +28,7 @@ var GameManipulator = {
   gamestate: 'OVER',
 
   // GameOver Position
-  gameOverOffset: [190, -75],
+  gameOverOffset: [190, -82], //old value [190, -75]
 
   // Stores an array of "sensors" (Ray tracings)
   // Positions are always relative to global "offset"


### PR DESCRIPTION
The actual value of the gameOverOffset is wrong.
So I updated the GameOver Position to [190, -82].

Now it works again and it restart the game automatically 



